### PR TITLE
fix: add overrides to @react-pdf/layout to resolve yoga-layout module…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "pdf renderer"
   ],
   "author": "Yasmin Lopes",
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "@react-pdf/layout": "3.6.4"
+  }
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds an override for the `@react-pdf/layout` package to version `3.6.4`.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R47): Added an override for the `@react-pdf/layout` package to version `3.6.4`.… issue